### PR TITLE
Introduce github actions to the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+    tags: ['**']
+
+env:
+  # Just a reassurance to mitigate sudden network connection problems
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: full
+
+  # We don't need any debug symbols on ci, this also speeds up builds a bunch
+  RUSTFLAGS: --deny warnings -Cdebuginfo=0
+  RUSTDOCFLAGS: --deny warnings
+
+jobs:
+  rust-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+
+      - run: cargo clippy --workspace
+      - run: cargo fmt --all -- --check
+
+  rust-test:
+    runs-on: ${{ matrix.os }}
+
+    # We don't want unstable jobs to fail our cicd
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        toolchain: [stable]
+        include:
+          - { os: ubuntu-latest, toolchain: beta }
+          - { os: ubuntu-latest, toolchain: nightly }
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+
+      - run: cargo +${{ matrix.toolchain }} build --workspace
+      - run: cargo +${{ matrix.toolchain }} test --workspace --no-run
+      - run: cargo +${{ matrix.toolchain }} test --workspace
+
+  rust-publish-crate:
+    # Publishing goes when we create a new git tag on the repo
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    # XXX: this job must execute only if all checks pass!
+    needs:
+      - rust-lint
+      - rust-test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - run: cargo publish --token ${{ secrets.CRATES_TOKEN }})


### PR DESCRIPTION
The proposed ci configuration runs
liniting (clippy and rustfmt) and tests in separate jobs.

There is also a job that publishes the crate to `crates.io` once we push
git tags to the repo.

@topecongiro I recommend enabling github actions in repo settings
The code also expects `CRATES_TOKEN` secret, this should also be configured in repo settings (just visit your account page on `crates.io`, there you should find the API token)