### PR TITLE
Refactor the error a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/topecongiro/advisory-lock-rs"
 
 [dependencies]
 log = "0.4"
-thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,11 @@
 //! [`RwLock`]: https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html
 //! [`File`]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
 use std::{
+    fmt,
     fs::{File, OpenOptions},
     io,
     ops::{Deref, DerefMut},
-    path::Path, fmt,
+    path::Path,
 };
 
 #[cfg(windows)]
@@ -79,6 +80,8 @@ impl fmt::Display for FileLockError {
         }
     }
 }
+
+impl std::error::Error for FileLockError {}
 
 /// An enumeration of types which represents how to acquire an advisory lock.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -163,10 +166,7 @@ impl AdvisoryFileLock {
 impl Drop for AdvisoryFileLock {
     fn drop(&mut self) {
         if let Err(err) = self.unlock() {
-            log::error!(
-                "Unlock_file failed during dropping: {}",
-                err
-            );
+            log::error!("Unlock_file failed during dropping: {}", err);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,8 @@ use std::{
     fs::{File, OpenOptions},
     io,
     ops::{Deref, DerefMut},
-    path::Path,
+    path::Path, fmt,
 };
-
-use thiserror::Error;
 
 #[cfg(windows)]
 mod windows;
@@ -65,14 +63,21 @@ mod windows;
 mod unix;
 
 /// An enumeration of possible errors which can occur while trying to acquire a lock.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum FileLockError {
     /// The file is already locked by other process.
-    #[error("the file is already locked")]
     AlreadyLocked,
     /// The error occurred during I/O operations.
-    #[error("I/O error: {0}")]
-    IOError(#[from] io::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for FileLockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FileLockError::AlreadyLocked => f.write_str("the file is already locked"),
+            FileLockError::Io(err) => write!(f, "I/O error: {}", err),
+        }
+    }
 }
 
 /// An enumeration of types which represents how to acquire an advisory lock.
@@ -116,7 +121,8 @@ impl AdvisoryFileLock {
             .read(true)
             .create(is_exclusive)
             .write(is_exclusive)
-            .open(path)?;
+            .open(path)
+            .map_err(FileLockError::Io)?;
 
         Ok(AdvisoryFileLock {
             file,
@@ -158,7 +164,7 @@ impl Drop for AdvisoryFileLock {
     fn drop(&mut self) {
         if let Err(err) = self.unlock() {
             log::error!(
-                "[AdvisoryFileLock] unlock_file failed during dropping: {}",
+                "Unlock_file failed during dropping: {}",
                 err
             );
         }
@@ -222,7 +228,7 @@ mod tests {
             let mut f1 = AdvisoryFileLock::new(&test_file, FileLockMode::Shared).unwrap();
             f1.lock().unwrap();
             let mut f2 = AdvisoryFileLock::new(&test_file, FileLockMode::Exclusive).unwrap();
-            assert!(f2.try_lock().is_err());
+            assert!(matches!(f2.try_lock(), Err(FileLockError::AlreadyLocked)));
         }
         std::fs::remove_file(&test_file).unwrap();
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -35,7 +35,7 @@ fn lock_file(
         let last_os_error = Error::last_os_error();
         return Err(match last_os_error.raw_os_error() {
             Some(code) if code == libc::EWOULDBLOCK => FileLockError::AlreadyLocked,
-            _ => FileLockError::IOError(last_os_error),
+            _ => FileLockError::Io(last_os_error),
         });
     }
 
@@ -47,6 +47,6 @@ fn unlock_file(raw_fd: RawFd) -> Result<(), FileLockError> {
     if result == 0 {
         Ok(())
     } else {
-        Err(FileLockError::IOError(Error::last_os_error()))
+        Err(FileLockError::Io(Error::last_os_error()))
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -5,7 +5,7 @@ use winapi::{
     shared::{
         minwindef::TRUE,
         ntdef::NULL,
-        winerror::{ERROR_LOCKED, ERROR_NOT_LOCKED},
+        winerror::{ERROR_LOCK_VIOLATION, ERROR_NOT_LOCKED},
     },
     um::{
         errhandlingapi::GetLastError,
@@ -78,7 +78,7 @@ fn lock_file(
     };
     if result != TRUE {
         return match unsafe { GetLastError() } {
-            ERROR_LOCKED => Err(FileLockError::AlreadyLocked),
+            ERROR_LOCK_VIOLATION => Err(FileLockError::AlreadyLocked),
             raw_error => Err(FileLockError::Io(io::Error::from_raw_os_error(
                 raw_error as i32,
             ))),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -29,7 +29,7 @@ impl AdvisoryFileLock {
     }
 
     pub(super) fn unlock_impl(&mut self) -> Result<(), FileLockError> {
-        Ok(unlock_file(self.file.as_raw_handle())?)
+        unlock_file(self.file.as_raw_handle())
     }
 }
 
@@ -79,7 +79,7 @@ fn lock_file(
     if result != TRUE {
         return match unsafe { GetLastError() } {
             ERROR_LOCKED => Err(FileLockError::AlreadyLocked),
-            raw_error => Err(FileLockError::IOError(std::io::Error::from_raw_os_error(
+            raw_error => Err(FileLockError::Io(io::Error::from_raw_os_error(
                 raw_error as i32,
             ))),
         };
@@ -88,7 +88,7 @@ fn lock_file(
     Ok(())
 }
 
-fn unlock_file(raw_handle: RawHandle) -> io::Result<()> {
+fn unlock_file(raw_handle: RawHandle) -> Result<(), FileLockError> {
     let mut overlapped = create_overlapped();
 
     let result = unsafe {
@@ -108,7 +108,7 @@ fn unlock_file(raw_handle: RawHandle) -> io::Result<()> {
         if raw_error == ERROR_NOT_LOCKED {
             Ok(())
         } else {
-            Err(std::io::Error::from_raw_os_error(raw_error as i32))
+            Err(FileLockError::Io(io::Error::from_raw_os_error(raw_error as i32)))
         }
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -108,7 +108,9 @@ fn unlock_file(raw_handle: RawHandle) -> Result<(), FileLockError> {
         if raw_error == ERROR_NOT_LOCKED {
             Ok(())
         } else {
-            Err(FileLockError::Io(io::Error::from_raw_os_error(raw_error as i32)))
+            Err(FileLockError::Io(io::Error::from_raw_os_error(
+                raw_error as i32,
+            )))
         }
     }
 }


### PR DESCRIPTION
For the main diff see this commit: a1d41b7
The second one (`cargo fmt`) seems to have changed the line endings, so the diff looks a bit too big at the first glance.

- Use the naming according to [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/naming.html)
- Drop dependency on `thiserror` - the less dependency the better!