### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
-      - run: cargo publish --token ${{ secrets.CRATES_TOKEN }})
+      - run: cargo publish --token ${{ secrets.CRATES_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 # advisory-lock-rs
 A cross-platform advisory file lock in Rust.
 
-For detailed documentation please visit [`docs.rs/advisory-locks`][docs].
+For detailed documentation please visit [`docs.rs/advisory-lock`][docs].


### PR DESCRIPTION
@topecongiro could you push a release of `advisory-lock-rs` to crates.io? It should be enough bump the version and push a git tag to the repo, ci will publish it automatically